### PR TITLE
Imports Format on Save

### DIFF
--- a/nvim/after/plugin/conform.lua
+++ b/nvim/after/plugin/conform.lua
@@ -1,10 +1,34 @@
+--  I'd prefer not to write this twice but imports from local lsp.lua weren't working for me
+local lspconfig = require('lspconfig')
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
+
+local M = {}
+
+function M.organize_imports()
+  local params = {
+    command = "_typescript.organizeImports",
+    arguments = { vim.api.nvim_buf_get_name(0) },
+    title = ""
+  }
+  vim.lsp.buf.execute_command(params)
+end
+
+lspconfig.tsserver.setup({
+  capabilities = capabilities,
+  commands = {
+    OrganizeImports = {
+      M.organize_imports,
+      description = "Organize Imports"
+    }
+  }
+})
+
 require("conform").setup({
   formatters_by_ft = {
     lua = { "stylua" },
     -- Conform will run multiple formatters sequentially
     python = { "black" },
     go = { "goimports", "gofumpt", "goimports-reviser" },
-
     -- Use a sub-list to run only the first available formatter
     javascript = { { "prettier", "eslint_d", "biome", "biome-check" } },
     css = { { "prettier", "biome", "biome-check" } },
@@ -41,6 +65,7 @@ require("conform").setup({
 vim.api.nvim_create_autocmd("BufWritePre", {
   pattern = "*",
   callback = function(args)
+    M.organize_imports()
     require("conform").format({ bufnr = args.buf })
   end,
 })
@@ -63,6 +88,7 @@ vim.api.nvim_create_user_command("Format", function(args)
     }
   end
   require("conform").format({ async = true, lsp_fallback = true, range = range })
+  M.organize_imports()
 end, { range = true })
 
 vim.api.nvim_set_keymap('n', '<leader>f', ':Format<CR>', { silent = true })

--- a/nvim/after/plugin/conform.lua
+++ b/nvim/after/plugin/conform.lua
@@ -25,6 +25,17 @@ require("conform").setup({
     sh = { 'beautysh' },
     astro = { "prettier" }
   },
+  python = function(bufnr)
+    if require("conform").get_formatter_info("biome", bufnr).available then
+      return { "biome" }
+    elseif require("conform").get_formatter_info("biome-check", bufnr).available then
+      return { "biome-check" }
+    else
+      return { "prettier", "eslint" }
+    end
+  end,
+  ["*"] = { "codespell" },
+  ["_"] = { "trim_whitespace" },
 })
 
 vim.api.nvim_create_autocmd("BufWritePre", {
@@ -39,9 +50,7 @@ require("conform").setup({
     timeout_ms = 500,
     lsp_fallback = true,
   },
-  format_after_save = {
-    lsp_fallback = true,
-  },
+  log_level = vim.log.levels.ERROR,
 })
 
 vim.api.nvim_create_user_command("Format", function(args)

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -28,25 +28,8 @@ lspconfig.rust_analyzer.setup({
 lspconfig.solargraph.setup({
   capabilities = capabilities
 })
-local M = {}
-
-function M.organize_imports()
-  local params = {
-    command = "_typescript.organizeImports",
-    arguments = { vim.api.nvim_buf_get_name(0) },
-    title = ""
-  }
-  vim.lsp.buf.execute_command(params)
-end
-
 lspconfig.tsserver.setup({
-  capabilities = capabilities,
-  commands = {
-    OrganizeImports = {
-      M.organize_imports,
-      description = "Organize Imports"
-    }
-  }
+  capabilities = capabilities
 })
 lspconfig.gopls.setup({
   capabilities = capabilities
@@ -139,6 +122,3 @@ vim.api.nvim_create_autocmd('LspAttach', {
     -- end, opts)
   end,
 })
-
-
-return M

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -28,8 +28,25 @@ lspconfig.rust_analyzer.setup({
 lspconfig.solargraph.setup({
   capabilities = capabilities
 })
+local M = {}
+
+function M.organize_imports()
+  local params = {
+    command = "_typescript.organizeImports",
+    arguments = { vim.api.nvim_buf_get_name(0) },
+    title = ""
+  }
+  vim.lsp.buf.execute_command(params)
+end
+
 lspconfig.tsserver.setup({
-  capabilities = capabilities
+  capabilities = capabilities,
+  commands = {
+    OrganizeImports = {
+      M.organize_imports,
+      description = "Organize Imports"
+    }
+  }
 })
 lspconfig.gopls.setup({
   capabilities = capabilities
@@ -122,3 +139,6 @@ vim.api.nvim_create_autocmd('LspAttach', {
     -- end, opts)
   end,
 })
+
+
+return M


### PR DESCRIPTION
### Context
This wasn't fun 😂 .

Currently, I am importing lsp twice for conform because I have to figure out local imports being pulled from the lsp.lua file require('lsp') did not work the way expected.

Either way this PR gives me a command called `organizeImports`, it runs in conform `Format` and now on command save.