### PR TITLE
Update Gitsigns to not be lazy loaded

### DIFF
--- a/nvim/lua/scottykaye/config/plugins/init.lua
+++ b/nvim/lua/scottykaye/config/plugins/init.lua
@@ -62,8 +62,10 @@ return {
     end,
   },
 
-  -- Git and version control
-  "nvim-lua/plenary.nvim",
+  {
+    "nvim-lua/plenary.nvim",
+    lazy = false,
+  },
   {
     "lewis6991/gitsigns.nvim",
     config = function()


### PR DESCRIPTION
### Context
Something like a race condition sometimes when gitsigns loads. Lets try loading it a head of time to fix it.